### PR TITLE
Ensure tokens revoked from Cognito aren't used to interact with Fractl

### DIFF
--- a/fractl/fractl/kernel/identity.fractl
+++ b/fractl/fractl/kernel/identity.fractl
@@ -37,43 +37,12 @@
 
 (entity
  :UserSession
- {:User :UUID
+ {:User :Identity
   :LoggedIn :Boolean})
 
 (event
  :UpdateUser
  {:UserDetails :UserExtra})
-
-(event
- :CreateUserSession
- {:UserId :UUID
-  :Session :Boolean})
-
-(event
- :UpdateUserSession
- {:UserId :UUID
-  :Session :Boolean})
-
-(dataflow
- :CreateUserSession
- {:UserSession
-  {:User :CreateUserSession.UserId
-   :LoggedIn :CreateUserSession.Session}})
-
-(dataflow
- :UpdateUserSession
- {:UserSession
-  {:User? :UpdateUserSession.UserId
-   :LoggedIn :UpdateUserSession.Session}})
-
-(event
- :FindUserSessionInfo
- {:User :UUID})
-
-(dataflow
- :FindUserSessionInfo
- {:UserSession
-  {:User? :FindUserSessionInfo.User}})
 
 (event
  :ForgotPassword

--- a/fractl/fractl/kernel/identity.fractl
+++ b/fractl/fractl/kernel/identity.fractl
@@ -35,9 +35,45 @@
  {:User :User
   :OtherDetails :Map})
 
+(entity
+ :UserSession
+ {:User :UUID
+  :LoggedIn :Boolean})
+
 (event
  :UpdateUser
  {:UserDetails :UserExtra})
+
+(event
+ :CreateUserSession
+ {:UserId :UUID
+  :Session :Boolean})
+
+(event
+ :UpdateUserSession
+ {:UserId :UUID
+  :Session :Boolean})
+
+(dataflow
+ :CreateUserSession
+ {:UserSession
+  {:User :CreateUserSession.UserId
+   :LoggedIn :CreateUserSession.Session}})
+
+(dataflow
+ :UpdateUserSession
+ {:UserSession
+  {:User? :UpdateUserSession.UserId
+   :LoggedIn :UpdateUserSession.Session}})
+
+(event
+ :FindUserSessionInfo
+ {:User :UUID})
+
+(dataflow
+ :FindUserSessionInfo
+ {:UserSession
+  {:User? :FindUserSessionInfo.User}})
 
 (event
  :ForgotPassword

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -615,6 +615,23 @@
       (get :id-token)
       (jwt/decode)))
 
+(defn upsert-user-session [evaluator user-id logged-in]
+  (if
+    (= (uh/get-status-of-response
+         (evaluator
+           {:Fractl.Kernel.Identity/Lookup_UserSession
+            {:User user-id}})) :not-found)
+    (evaluator
+      {:Fractl.Kernel.Identity/Create_UserSession
+       {:Instance
+        {:Fractl.Kernel.Identity/UserSession
+         {:User     user-id
+          :LoggedIn logged-in}}}})
+    (evaluator
+      {:Fractl.Kernel.Identity/Update_UserSession
+       {:User user-id
+        :Data {:LoggedIn logged-in}}})))
+
 (defn- process-login [evaluator [auth-config _ :as _auth-info] request]
   (if-not auth-config
     (internal-error "cannot process login - authentication not enabled")
@@ -630,21 +647,7 @@
                            :event evobj
                            :eval evaluator))
                   user-id (get (decode-jwt-token-from-response result) :sub)]
-              (if
-                (= (uh/get-status-of-response
-                     (evaluator
-                       {:Fractl.Kernel.Identity/Lookup_UserSession
-                        {:User user-id}})) :not-found)
-                (evaluator
-                  {:Fractl.Kernel.Identity/Create_UserSession
-                   {:Instance
-                    {:Fractl.Kernel.Identity/UserSession
-                     {:User     user-id
-                      :LoggedIn true}}}})
-                (evaluator
-                  {:Fractl.Kernel.Identity/Update_UserSession
-                   {:User user-id
-                    :Data {:LoggedIn true}}}))
+              (upsert-user-session evaluator user-id true)
               (ok {:result result} data-fmt))
             (catch Exception ex
               (log/warn ex)
@@ -804,21 +807,7 @@
                       (assoc
                        auth-config
                        :sub sub))]
-          (if
-            (= (uh/get-status-of-response
-                 (evaluator
-                   {:Fractl.Kernel.Identity/Lookup_UserSession
-                    {:User (:username sub)}})) :not-found)
-            (evaluator
-              {:Fractl.Kernel.Identity/Create_UserSession
-               {:Instance
-                {:Fractl.Kernel.Identity/UserSession
-                 {:User     (:username sub)
-                  :LoggedIn false}}}})
-            (evaluator
-              {:Fractl.Kernel.Identity/Update_UserSession
-               {:User (:username sub)
-                :Data {:LoggedIn false}}}))
+          (upsert-user-session evaluator (:username sub) false)
           (ok {:result result} data-fmt))
         (catch Exception ex
           (log/warn ex)

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -624,10 +624,21 @@
                            :event evobj
                            :eval evaluator))
                   user-id (get (jwt/decode (get-in result [:authentication-result :id-token])) :sub)]
-              (evaluator
-                {:Fractl.Kernel.Identity/CreateUserSession
-                   {:UserId user-id
-                    :Session true}})
+              (if
+                (= (uh/get-status-of-response
+                     (evaluator
+                       {:Fractl.Kernel.Identity/Lookup_UserSession
+                        {:User user-id}})) :not-found)
+                (evaluator
+                  {:Fractl.Kernel.Identity/Create_UserSession
+                   {:Instance
+                    {:Fractl.Kernel.Identity/UserSession
+                     {:User     user-id
+                      :LoggedIn true}}}})
+                (evaluator
+                  {:Fractl.Kernel.Identity/Update_UserSession
+                   {:User user-id
+                    :Data {:LoggedIn true}}}))
               (ok {:result result} data-fmt))
             (catch Exception ex
               (log/warn ex)
@@ -787,10 +798,21 @@
                       (assoc
                        auth-config
                        :sub sub))]
-          (evaluator
-            {:Fractl.Kernel.Identity/UpdateUserSession
-             {:UserId (:username sub)
-              :Session false}})
+          (if
+            (= (uh/get-status-of-response
+                 (evaluator
+                   {:Fractl.Kernel.Identity/Lookup_UserSession
+                    {:User (:username sub)}})) :not-found)
+            (evaluator
+              {:Fractl.Kernel.Identity/Create_UserSession
+               {:Instance
+                {:Fractl.Kernel.Identity/UserSession
+                 {:User     (:username sub)
+                  :LoggedIn false}}}})
+            (evaluator
+              {:Fractl.Kernel.Identity/Update_UserSession
+               {:User (:username sub)
+                :Data {:LoggedIn false}}}))
           (ok {:result result} data-fmt))
         (catch Exception ex
           (log/warn ex)
@@ -958,13 +980,10 @@
 
 (defn- handle-request-auth [request evaluator]
   (let [user (get-in request [:identity :sub])
-        logged-in-status (get
-                           (first
-                             (get
-                               (first
-                                 (evaluator
-                                   {:Fractl.Kernel.Identity/FindUserSessionInfo
-                                    {:User user}})) :result)) :LoggedIn)]
+        logged-in-status (uh/get-data-in-response-result
+                           (evaluator
+                             {:Fractl.Kernel.Identity/Lookup_UserSession
+                              {:User user}}) :LoggedIn)]
     (try
       (when-not (and (buddy/authenticated? request) (= logged-in-status true))
         (log/info (str "unauthorized request - " request))

--- a/src/fractl/model/fractl/kernel/identity.cljc
+++ b/src/fractl/model/fractl/kernel/identity.cljc
@@ -33,9 +33,38 @@
 (entity
  :Fractl.Kernel.Identity/UserExtra
  {:User :Fractl.Kernel.Identity/User, :OtherDetails :Map})
+(entity
+ :Fractl.Kernel.Identity/UserSession
+ {:User :UUID, :LoggedIn :Boolean})
 (event
  :Fractl.Kernel.Identity/UpdateUser
  {:UserDetails :Fractl.Kernel.Identity/UserExtra})
+(event
+ :Fractl.Kernel.Identity/CreateUserSession
+ {:UserId :UUID, :Session :Boolean})
+(event
+ :Fractl.Kernel.Identity/UpdateUserSession
+ {:UserId :UUID, :Session :Boolean})
+(dataflow
+ :Fractl.Kernel.Identity/CreateUserSession
+ #:Fractl.Kernel.Identity{:UserSession
+                          {:User
+                           :Fractl.Kernel.Identity/CreateUserSession.UserId,
+                           :LoggedIn
+                           :Fractl.Kernel.Identity/CreateUserSession.Session}})
+(dataflow
+ :Fractl.Kernel.Identity/UpdateUserSession
+ #:Fractl.Kernel.Identity{:UserSession
+                          {:User?
+                           :Fractl.Kernel.Identity/UpdateUserSession.UserId,
+                           :LoggedIn
+                           :Fractl.Kernel.Identity/UpdateUserSession.Session}})
+(event :Fractl.Kernel.Identity/FindUserSessionInfo {:User :UUID})
+(dataflow
+ :Fractl.Kernel.Identity/FindUserSessionInfo
+ #:Fractl.Kernel.Identity{:UserSession
+                          {:User?
+                           :Fractl.Kernel.Identity/FindUserSessionInfo.User}})
 (event :Fractl.Kernel.Identity/ForgotPassword {:Username :Email})
 (event
  :Fractl.Kernel.Identity/ConfirmForgotPassword
@@ -61,4 +90,4 @@
  {:Username :Email})
 (def
  Fractl_Kernel_Identity___COMPONENT_ID__
- "71ce1964-7f92-4c37-9d4b-c1ac72aff9f2")
+ "1a09eb7f-cad6-4aa4-bc7b-5204d6fc352f")

--- a/src/fractl/model/fractl/kernel/identity.cljc
+++ b/src/fractl/model/fractl/kernel/identity.cljc
@@ -35,36 +35,10 @@
  {:User :Fractl.Kernel.Identity/User, :OtherDetails :Map})
 (entity
  :Fractl.Kernel.Identity/UserSession
- {:User :UUID, :LoggedIn :Boolean})
+ {:User :Identity, :LoggedIn :Boolean})
 (event
  :Fractl.Kernel.Identity/UpdateUser
  {:UserDetails :Fractl.Kernel.Identity/UserExtra})
-(event
- :Fractl.Kernel.Identity/CreateUserSession
- {:UserId :UUID, :Session :Boolean})
-(event
- :Fractl.Kernel.Identity/UpdateUserSession
- {:UserId :UUID, :Session :Boolean})
-(dataflow
- :Fractl.Kernel.Identity/CreateUserSession
- #:Fractl.Kernel.Identity{:UserSession
-                          {:User
-                           :Fractl.Kernel.Identity/CreateUserSession.UserId,
-                           :LoggedIn
-                           :Fractl.Kernel.Identity/CreateUserSession.Session}})
-(dataflow
- :Fractl.Kernel.Identity/UpdateUserSession
- #:Fractl.Kernel.Identity{:UserSession
-                          {:User?
-                           :Fractl.Kernel.Identity/UpdateUserSession.UserId,
-                           :LoggedIn
-                           :Fractl.Kernel.Identity/UpdateUserSession.Session}})
-(event :Fractl.Kernel.Identity/FindUserSessionInfo {:User :UUID})
-(dataflow
- :Fractl.Kernel.Identity/FindUserSessionInfo
- #:Fractl.Kernel.Identity{:UserSession
-                          {:User?
-                           :Fractl.Kernel.Identity/FindUserSessionInfo.User}})
 (event :Fractl.Kernel.Identity/ForgotPassword {:Username :Email})
 (event
  :Fractl.Kernel.Identity/ConfirmForgotPassword
@@ -90,4 +64,4 @@
  {:Username :Email})
 (def
  Fractl_Kernel_Identity___COMPONENT_ID__
- "1a09eb7f-cad6-4aa4-bc7b-5204d6fc352f")
+ "72dc903d-669e-4f59-9d4f-1e2f8fc60215")

--- a/src/fractl/model/fractl/kernel/lang.cljc
+++ b/src/fractl/model/fractl/kernel/lang.cljc
@@ -24,7 +24,7 @@
 (attribute :Fractl.Kernel.Lang/String {:check k/kernel-string?})
 (attribute
  :Fractl.Kernel.Lang/Keyword
- {:check (fn* [p1__276#] (or (keyword? p1__276#) (string? p1__276#)))})
+ {:check (fn* [p1__284#] (or (keyword? p1__284#) (string? p1__284#)))})
 (attribute :Fractl.Kernel.Lang/Path {:check k/path?})
 (attribute :Fractl.Kernel.Lang/DateTime {:check k/date-time?})
 (attribute :Fractl.Kernel.Lang/Date {:check k/date?})
@@ -119,4 +119,4 @@
     :paths [:Fractl.Kernel.Lang/DataSync]})])
 (def
  Fractl_Kernel_Lang___COMPONENT_ID__
- "ca825f01-cef3-4c83-8584-7bf2be773f78")
+ "ece2ad09-ed12-41f9-938a-f3c0b13cf702")

--- a/src/fractl/model/fractl/kernel/lang.cljc
+++ b/src/fractl/model/fractl/kernel/lang.cljc
@@ -119,4 +119,4 @@
     :paths [:Fractl.Kernel.Lang/DataSync]})])
 (def
  Fractl_Kernel_Lang___COMPONENT_ID__
- "ece2ad09-ed12-41f9-938a-f3c0b13cf702")
+ "4e1c1755-a235-45bf-8a56-3f032ce192df")

--- a/src/fractl/model/fractl/kernel/rbac.cljc
+++ b/src/fractl/model/fractl/kernel/rbac.cljc
@@ -26,7 +26,7 @@
 (defn-
  crud-list?
  [xs]
- (every? (fn* [p1__280#] (some #{p1__280#} oprs)) (set xs)))
+ (every? (fn* [p1__288#] (some #{p1__288#} oprs)) (set xs)))
 (entity
  :Fractl.Kernel.Rbac/Privilege
  {:Name {:type :String, :default u/uuid-string, li/guid true},
@@ -64,7 +64,7 @@
    " in ("
    (s/join
     ","
-    (map (fn* [p1__281#] (str "'" (str p1__281#) "'")) role-names))
+    (map (fn* [p1__289#] (str "'" (str p1__289#) "'")) role-names))
    "))")))
 (dataflow
  :Fractl.Kernel.Rbac/FindPrivilegeAssignments
@@ -84,7 +84,7 @@
    " in ("
    (s/join
     ","
-    (map (fn* [p1__282#] (str "'" (str p1__282#) "'")) names))
+    (map (fn* [p1__290#] (str "'" (str p1__290#) "'")) names))
    "))")))
 (dataflow
  :Fractl.Kernel.Rbac/FindPrivileges
@@ -115,4 +115,4 @@
                        :Assignee :String}})
 (def
  Fractl_Kernel_Rbac___COMPONENT_ID__
- "3c15a20a-2a8c-447f-89af-cf6951772c98")
+ "562b0bac-6095-4530-a994-35d6c7d747fc")

--- a/src/fractl/model/fractl/kernel/rbac.cljc
+++ b/src/fractl/model/fractl/kernel/rbac.cljc
@@ -115,4 +115,4 @@
                        :Assignee :String}})
 (def
  Fractl_Kernel_Rbac___COMPONENT_ID__
- "562b0bac-6095-4530-a994-35d6c7d747fc")
+ "602c223a-b71d-4562-8ded-3032e7a2f0f3")

--- a/src/fractl/model/fractl/kernel/store.cljc
+++ b/src/fractl/model/fractl/kernel/store.cljc
@@ -78,4 +78,4 @@
   :NewName {:type :Path, :optional true}})
 (def
  Fractl_Kernel_Store___COMPONENT_ID__
- "88bb4c2b-22d6-43a3-9878-b5686995b1a9")
+ "a81b19b6-7d11-46d7-a246-5d665fdafd07")

--- a/src/fractl/model/fractl/kernel/store.cljc
+++ b/src/fractl/model/fractl/kernel/store.cljc
@@ -45,7 +45,7 @@
     (seq
      (filter
       identity
-      (mapv (fn* [p1__284#] (p1__284# obj)) [:add :alter :rename])))]
+      (mapv (fn* [p1__292#] (p1__292# obj)) [:add :alter :rename])))]
    (every? map? xs)
    true)
   (maybe-all? rename-col? :rename obj)
@@ -78,4 +78,4 @@
   :NewName {:type :Path, :optional true}})
 (def
  Fractl_Kernel_Store___COMPONENT_ID__
- "3d41072c-13d0-4337-a1a9-4124f41d64ed")
+ "88bb4c2b-22d6-43a3-9878-b5686995b1a9")

--- a/src/fractl/util/http.cljc
+++ b/src/fractl/util/http.cljc
@@ -188,3 +188,9 @@
                       "/" (name entity))
            :vars (map name path)}
           (recur (conj path (-> parent-entity first last))))))))
+
+(defn get-status-of-response [request]
+  (get (first request) :status))
+
+(defn get-data-in-response-result [request data]
+  (get (first (get (first request) :result)) data))


### PR DESCRIPTION
Keep track of UserSessions and safe guard against Users who have logged out from Design Studio yet, use the JWT token via HTTP requests.