### PR TITLE
Don't handle complicated nesting on chat-response

### DIFF
--- a/src/fractl/gpt/core.cljc
+++ b/src/fractl/gpt/core.cljc
@@ -193,13 +193,12 @@
       (apply f (rest exp))))
   exps)
 
-(defn get-model [response]
+(defn get-model [chat-response]
   (try
-    (when-let [c (chat-response response)]
-      (let [exps (rest (u/parse-string (str "(do " c ")")))]
-        (when (= 'component (ffirst exps))
-          {:model (make-model (first exps))
-           :component (verify-component-defs exps)})))
+    (let [exps (rest (u/parse-string (str "(do " chat-response ")")))]
+      (when (= 'component (ffirst exps))
+        {:model     (make-model (first exps))
+         :component (verify-component-defs exps)}))
     (catch #?(:clj Exception :cljs :default) ex
       (log/warn ex))))
 


### PR DESCRIPTION
Sometimes chat-response which we might send it over to _ai/ might be complicated nesting with other additional information like texts and other data-structures. It shouldn't be Fractl that should handle such, so, it must be the responsibility of client to only send the proper fractl code to Fractl side of things.