### PR TITLE
fix loading when last line is commented (with semicolon)

### DIFF
--- a/src/fractl/lang/tools/loader.cljc
+++ b/src/fractl/lang/tools/loader.cljc
@@ -31,7 +31,7 @@
 (defn- fetch-declared-names [spec-or-script]
   (loop [exps #?(:clj (if-not (string? spec-or-script)
                         spec-or-script
-                        (read-string (str "(do" (slurp spec-or-script) ")")))
+                        (read-string (str "(do" (slurp spec-or-script) "\n)")))
                  :cljs spec-or-script)
          result {}]
     (if-let [exp (first exps)]


### PR DESCRIPTION
This PR fixes the corner-case when the loader fails for code ending with comment on he last line of the file:

```clojure
; some comment (last line in the file)
```

with the following stack trace:

```
Exception in thread "main" java.lang.RuntimeException: EOF while reading
	at clojure.lang.Util.runtimeException(Util.java:221)
	at clojure.lang.LispReader.readDelimitedList(LispReader.java:1403)
	at clojure.lang.LispReader$ListReader.invoke(LispReader.java:1243)
	at clojure.lang.LispReader.read(LispReader.java:285)
	at clojure.lang.LispReader.read(LispReader.java:216)
	at clojure.lang.LispReader.read(LispReader.java:205)
	at clojure.lang.RT.readString(RT.java:1879)
	at clojure.lang.RT.readString(RT.java:1874)
	at clojure.core$read_string.invokeStatic(core.clj:3803)
	at clojure.core$read_string.invoke(core.clj:3793)
	at fractl.lang.tools.loader$fetch_declared_names.invokeStatic(loader.cljc:34)
	at fractl.lang.tools.loader$fetch_declared_names.invoke(loader.cljc:31)
	at fractl.lang.tools.loader$load_script.invokeStatic(loader.cljc:132)
	at fractl.lang.tools.loader$load_script.invoke(loader.cljc:116)
	at fractl.lang.tools.loader$load_components$fn__31071.invoke(loader.cljc:214)
	at clojure.core$mapv$fn__8468.invoke(core.clj:6914)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:343)
	at clojure.core$reduce.invokeStatic(core.clj:6829)
	at clojure.core$mapv.invokeStatic(core.clj:6905)
	at clojure.core$mapv.invoke(core.clj:6905)
	at fractl.lang.tools.loader$load_components.invokeStatic(loader.cljc:213)
	at fractl.lang.tools.loader$load_components.invoke(loader.cljc:210)
	at fractl.lang.tools.loader$load_components_from_model.invokeStatic(loader.cljc:234)
	at fractl.lang.tools.loader$load_components_from_model.invoke(loader.cljc:232)
	at fractl.lang.tools.loader$load_components_from_model.invokeStatic(loader.cljc:238)
	at fractl.lang.tools.loader$load_components_from_model.invoke(loader.cljc:232)
	at fractl.lang.tools.loader$read_components_from_model.invokeStatic(loader.cljc:242)
	at fractl.lang.tools.loader$read_components_from_model.invoke(loader.cljc:240)
	at fractl.lang.tools.build$build_model.invokeStatic(build.clj:323)
	at fractl.lang.tools.build$build_model.invoke(build.clj:310)
	at fractl.lang.tools.build$load_model.invokeStatic(build.clj:369)
	at fractl.lang.tools.build$load_model.invoke(build.clj:368)
	at fractl.core$call_after_load_model$fn__31560.invoke(core.clj:417)
	at fractl.core$call_after_load_model.invokeStatic(core.clj:416)
	at fractl.core$call_after_load_model.invoke(core.clj:413)
	at fractl.core$call_after_load_model.invokeStatic(core.clj:422)
	at fractl.core$call_after_load_model.invoke(core.clj:413)
	at fractl.core$_main$fn__31579.invoke(core.clj:465)
	at fractl.core$run_plain_option.invokeStatic(core.clj:370)
	at fractl.core$run_plain_option.invoke(core.clj:368)
	at clojure.core$partial$fn__5857.invoke(core.clj:2629)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:662)
	at fractl.core$_main$fn__31577.invoke(core.clj:464)
	at clojure.core$map$fn__5884.invoke(core.clj:2759)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$some.invokeStatic(core.clj:2696)
	at clojure.core$some.invoke(core.clj:2696)
	at fractl.core$_main.invokeStatic(core.clj:462)
	at fractl.core$_main.doInvoke(core.clj:444)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at fractl.core.main(Unknown Source)
```