### PR TITLE
Loader step wise

### DIFF
--- a/src/fractl/lang/tools/loader.cljc
+++ b/src/fractl/lang/tools/loader.cljc
@@ -290,8 +290,7 @@
                  (u/throw-ex (str "failed to intern " exp)))
                (catch js/Object _
                  (let [corrupted-exp (get-corrupted-entity-form (second exp) (first exp))]
-                   (apply intern (rest (fqn corrupted-exp))))))))
-         (raw/intern-component cname component-spec)))
+                   (apply intern (rest (fqn corrupted-exp))))))))))
 
      (defn load-components-from-model [model callback]
        (doseq [c (:components model)]

--- a/src/fractl/model/fractl/kernel/identity.cljc
+++ b/src/fractl/model/fractl/kernel/identity.cljc
@@ -22,6 +22,11 @@
   :Email {:type :Email, li/guid true},
   :UserData {:type :Map, :optional true},
   :AppId {:type :UUID, :default u/uuid-string, :indexed true}})
+(dataflow
+ [:after :delete :Fractl.Kernel.Identity/User]
+ [:delete :Fractl.Kernel.Rbac/InstancePrivilegeAssignment {:Assignee :Instance.Email}]
+ [:delete :Fractl.Kernel.Rbac/OwnershipAssignment {:Assignee :Instance.Email}]
+ [:delete :Fractl.Kernel.Rbac/RoleAssignment {:Assignee :Instance.Email}])
 (event
  :Fractl.Kernel.Identity/SignUp
  {:User :Fractl.Kernel.Identity/User})

--- a/src/fractl/model/fractl/kernel/identity.cljc
+++ b/src/fractl/model/fractl/kernel/identity.cljc
@@ -22,11 +22,6 @@
   :Email {:type :Email, li/guid true},
   :UserData {:type :Map, :optional true},
   :AppId {:type :UUID, :default u/uuid-string, :indexed true}})
-(dataflow
- [:after :delete :Fractl.Kernel.Identity/User]
- [:delete :Fractl.Kernel.Rbac/InstancePrivilegeAssignment {:Assignee :Instance.Email}]
- [:delete :Fractl.Kernel.Rbac/OwnershipAssignment {:Assignee :Instance.Email}]
- [:delete :Fractl.Kernel.Rbac/RoleAssignment {:Assignee :Instance.Email}])
 (event
  :Fractl.Kernel.Identity/SignUp
  {:User :Fractl.Kernel.Identity/User})


### PR DESCRIPTION
When a component's entities/relationships/dataflows are loaded one by one, if any of them is fails (is "corrupted"), we check it using try-catch block. To indicate it's failed so that Design Studio can render the erroneous entity, we create a dummy entity for that with its name and type (entity/relationship/so on) and mark it as corrupted via meta so that Design Studio doesn't treat it as a regular entity.

```
(defn get-corrupted-entity-form [entity-name t]
       `(~'entity
         ~entity-name
         {:meta {:corrupt true, :type ~t}}))
```

Also check https://github.com/fractl-io/design-studio/pull/214