### PR TITLE
Refactor auth callback

### DIFF
--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -959,6 +959,7 @@
                          (assoc
                           (create-event post-signup-event-name)
                           :SignupResult sign-up-result :SignupRequest {:User user})))))
+                  (upsert-user-session (:sub user) true)
                   {:status  302
                    :headers {"Location"
                              (str (or redirect-query redirect-url)

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -664,8 +664,9 @@
               (ok {:result result} data-fmt))
             (catch Exception ex
               (log/warn ex)
-              (unauthorized (str "Login failed. "
-                                 (.getMessage ex) "LOGIN_ERROR") data-fmt)))))
+              (unauthorized
+               (str "Login failed. "
+                    (.getMessage ex)) data-fmt "LOGIN_ERROR")))))
       (bad-request
        (str "unsupported content-type in request - "
             (request-content-type request)) "UNSUPPORTED_CONTENT_TYPE"))))
@@ -721,7 +722,7 @@
             (catch Exception ex
               (log/warn ex)
               (unauthorized (str "Verify user failed. "
-                                 (.getMessage ex)) data-fmt)))))
+                                 (.getMessage ex)) data-fmt "CONFIRM_SIGNUP_ERROR")))))
       (bad-request
        (str "unsupported content-type in request - "
             (request-content-type request)) "UNSUPPORTED_CONTENT_TYPE"))))

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -937,20 +937,20 @@
           (if-let [token (:id_token tokens)]
             (if-let [user (verify-token token)]
               (when (:email user)
-                (let [user {:Email (:email user)
+                (let [user-obj {:Email (:email user)
                             :Name (str (:given_name user) " " (:family_name user))
                             :FirstName (:given_name user)
                             :LastName (:family_name user)}
                       sign-up-request
                       {:Fractl.Kernel.Identity/SignUp
-                       {:User {:Fractl.Kernel.Identity/User user}}}
+                       {:User {:Fractl.Kernel.Identity/User user-obj}}}
                       new-sign-up
                       (= :not-found
                          (:status
                           (first
                            (evaluator
                             {:Fractl.Kernel.Identity/FindUser
-                             {:Email (:Email user)}}))))]
+                             {:Email (:Email user-obj)}}))))]
                   (when new-sign-up
                     (let [sign-up-result (u/safe-ok-result (evaluator sign-up-request))]
                       (when call-post-signup
@@ -958,7 +958,7 @@
                          evaluator
                          (assoc
                           (create-event post-signup-event-name)
-                          :SignupResult sign-up-result :SignupRequest {:User user})))))
+                          :SignupResult sign-up-result :SignupRequest {:User user-obj})))))
                   (upsert-user-session (:sub user) true)
                   {:status  302
                    :headers {"Location"


### PR DESCRIPTION
Previously, the workflow was this: get the ID token from Cognito Google Auth UI directly and then call `/_authcallback` endpoint manually from frontend to optionally execute post signup. The limitation was, it didn't give us refresh token.

I refactored it such that:

- Google Auth directly leads us to /_authcallback with a 'code'. 
- We call a REST endpoint of Cognito to get `id_token` and `refresh_token` for that code
- if successful, redirect the user to a provided (in the request) or default (in env var) redirect URL, usually the application frontend