### PR TITLE
Issue 1223 - path query syntax

### DIFF
--- a/src/fractl/lang/internal.cljc
+++ b/src/fractl/lang/internal.cljc
@@ -51,7 +51,7 @@
                    :offset :join :left-join
                    :right-join :desc])
 (def oprs (concat query-cmpr-oprs sql-keywords [:not :and :or :between :in]))
-(def macro-names #{:match :try :rethrow-after :for-each :delete :query :await :entity :eval})
+(def macro-names #{:match :try :rethrow-after :for-each :delete :query :await :entity :eval :?})
 (def property-names #{:meta :ui :rbac})
 
 (defn operator? [x]

--- a/test/fractl/test/features03.cljc
+++ b/test/fractl/test/features03.cljc
@@ -465,4 +465,4 @@
   (let [a (tu/first-result {:I1223/Create_A {:Instance {:I1223/A {:X 100}}}})
         a? (partial cn/instance-of? :I1223/A)]
     (is (a? a))
-    (println (tu/eval-all-dataflows {:I1223/LookupC {:A (:Id a) :C "c1" :Z 20}}))))
+    (is (tu/eval-all-dataflows {:I1223/LookupC {:A (:Id a) :C "c1" :Z 20}}))))

--- a/test/fractl/test/features03.cljc
+++ b/test/fractl/test/features03.cljc
@@ -457,12 +457,12 @@
     (entity :I1223/C {:id :Identity :Z :Int :Name {:type :String :id true}})
     (relationship :I1223/AB {:meta {:contains [:I1223/A :I1223/B]}})
     (relationship :I1223/BC {:meta {:contains [:I1223/B :I1223/C]}})
-    #_(dataflow
+    (dataflow
      :I1223/LookupC
      [:? {:I1223/A {:Id :I1223/LookupC.A}}
       :I1223/AB {:I1223/B {:Y 1}}
-      :I1223/BC {:I1223/C {:Name :I1223/LookupC.C, :Z :I1223/LookupC.Z}}])
-    )
+      :I1223/BC {:I1223/C {:Name :I1223/LookupC.C, :Z :I1223/LookupC.Z}}]))
   (let [a (tu/first-result {:I1223/Create_A {:Instance {:I1223/A {:X 100}}}})
         a? (partial cn/instance-of? :I1223/A)]
-    (is (a? a))))
+    (is (a? a))
+    (println (tu/eval-all-dataflows {:I1223/LookupC {:A (:Id a) :C "c1" :Z 20}}))))

--- a/test/fractl/test/features03.cljc
+++ b/test/fractl/test/features03.cljc
@@ -449,3 +449,20 @@
     (is (cn/instance-of? :Cbp/A a))
     (is (cn/instance-of? :Cbp/B b))
     (is (cn/same-instance? b (tu/first-result {:Cbp/FindB {:ParentPath (li/path-attr b)}})))))
+
+(deftest issue-1223-rel-syntax
+  (defcomponent :I1223
+    (entity :I1223/A {:Id :Identity :X :Int})
+    (entity :I1223/B {:Id :Identity :Y {:type :Int :id true}})
+    (entity :I1223/C {:id :Identity :Z :Int :Name {:type :String :id true}})
+    (relationship :I1223/AB {:meta {:contains [:I1223/A :I1223/B]}})
+    (relationship :I1223/BC {:meta {:contains [:I1223/B :I1223/C]}})
+    #_(dataflow
+     :I1223/LookupC
+     [:? {:I1223/A {:Id :I1223/LookupC.A}}
+      :I1223/AB {:I1223/B {:Y 1}}
+      :I1223/BC {:I1223/C {:Name :I1223/LookupC.C, :Z :I1223/LookupC.Z}}])
+    )
+  (let [a (tu/first-result {:I1223/Create_A {:Instance {:I1223/A {:X 100}}}})
+        a? (partial cn/instance-of? :I1223/A)]
+    (is (a? a))))

--- a/test/fractl/test/fixes02.cljc
+++ b/test/fractl/test/fixes02.cljc
@@ -688,3 +688,15 @@
                        {:Id (:Id e)}}))))
       (let [es (tu/result {:I1062/LookupAll_E {}})]
         (is (and (= 1 (count es)) (cn/same-instance? e2 (first es))))))))
+
+(deftest alias-bug-in-where-query
+  (defcomponent :Abwq
+    (entity :Abwq/A {:Id :Identity :X :Int})
+    (dataflow
+     :Abwq/FindX
+     {:Abwq/A? {:where [:= :Id :Abwq/FindX.A]} :as [:A]}
+     :A.X))
+  (let [a1 (tu/first-result {:Abwq/Create_A {:Instance {:Abwq/A {:X 100}}}})
+        a2 (tu/first-result {:Abwq/Create_A {:Instance {:Abwq/A {:X 200}}}})]
+    (is (= 300 (+ (tu/result {:Abwq/FindX {:A (:Id a1)}})
+                  (tu/result {:Abwq/FindX {:A (:Id a2)}}))))))


### PR DESCRIPTION
fixes #1223 

Also includes:
1. a bug fix in lookup based on `:where` query alias.
2. test for a copilot use-case