### PR TITLE
Issue 1236 meta fix

### DIFF
--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -2038,3 +2038,21 @@
        :ignore record-name
        (u/throw-ex (str "cannot cascade delete children - " record-name)))))
   ([delfn inst] (maybe-delete-children delfn (instance-type-kw inst) inst)))
+
+(defn encode-expressions-in-schema [scm]
+  (let [norm-scm (mapv (fn [[k v]]
+                         [k (cond
+                              (map? v)
+                              (encode-expressions-in-schema v)
+
+                              (vector? v) v
+
+                              (or (fn? v) (seqable? v)) :fn
+
+                              :else
+                              (let [[c n] (li/split-path v)]
+                                (if (= c :Fractl.Kernel.Lang)
+                                  n
+                                  v)))])
+                       (dissoc scm li/event-context))]
+    (into {} norm-scm)))

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -229,13 +229,16 @@
 
 (defn- paths-info [component]
   (mapv (fn [n] {(subs (str n) 1)
-                 {"post" {"parameters" (cn/event-schema n)}}})
+                 {"post" {"parameters" (cn/encode-expressions-in-schema (cn/event-schema n))}}})
         (cn/event-names component)))
 
-(defn- schemas-info [component]
-  (mapv (fn [n]
-          {n (lr/find-entity n)})
-        (cn/entity-names component)))
+(defn- find-schema [fetch-names find-schema]
+  (mapv (fn [n] {n (cn/encode-expressions-in-schema (find-schema n))}) (fetch-names)))
+
+(defn- schema-info [component]
+  {:records (find-schema #(cn/record-names component) lr/find-record)
+   :entities (find-schema #(cn/entity-names component) lr/find-entity)
+   :relationships (find-schema #(cn/relationship-names component) lr/find-relationship)})
 
 (defn- request-object [request]
   (if-let [data-fmt (find-data-format request)]
@@ -246,7 +249,7 @@
 (defn- process-meta-request [[_ maybe-unauth] request]
   (or (maybe-unauth request)
       (let [c (keyword (get-in request [:params :component]))]
-        (ok {:paths (paths-info c) :schemas (schemas-info c)}))))
+        (ok {:paths (paths-info c) :schema (schema-info c)}))))
 
 (defn- process-gpt-chat [[_ maybe-unauth] request]
   (or (maybe-unauth request)

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -252,7 +252,7 @@
         (if-not (seq params)
           (ok {:components (cn/component-names)})
           (let [c (keyword (:component params))]
-            (ok {:paths (paths-info c) :schema (schema-info c)}))))))
+            (ok {:paths (paths-info c) :schema (schema-info c) :component-edn (str (lr/as-edn c))}))))))
 
 (defn- process-gpt-chat [[_ maybe-unauth] request]
   (or (maybe-unauth request)

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -11,8 +11,9 @@
             [buddy.core.keys :as buddykeys]
             [buddy.sign.jwt :as buddyjwt]
             [fractl.compiler :as compiler]
-            [fractl.lang :as ln]
             [clj-time.core :as time]
+            [fractl.lang :as ln]
+            [fractl.lang.raw :as lr]
             [fractl.lang.internal :as li]
             [fractl.paths.internal :as pi]
             [fractl.util :as u]
@@ -232,7 +233,8 @@
         (cn/event-names component)))
 
 (defn- schemas-info [component]
-  (mapv (fn [n] {n (cn/entity-schema n)})
+  (mapv (fn [n]
+          {n (lr/find-entity n)})
         (cn/entity-names component)))
 
 (defn- request-object [request]

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -248,8 +248,11 @@
 
 (defn- process-meta-request [[_ maybe-unauth] request]
   (or (maybe-unauth request)
-      (let [c (keyword (get-in request [:params :component]))]
-        (ok {:paths (paths-info c) :schema (schema-info c)}))))
+      (let [params (:params request)]
+        (if-not (seq params)
+          (ok {:components (cn/component-names)})
+          (let [c (keyword (:component params))]
+            (ok {:paths (paths-info c) :schema (schema-info c)}))))))
 
 (defn- process-gpt-chat [[_ maybe-unauth] request]
   (or (maybe-unauth request)
@@ -1054,6 +1057,7 @@
            (POST uh/register-magiclink-prefix [] (:register-magiclink handlers))
            (GET uh/get-magiclink-prefix [] (:get-magiclink handlers))
            (POST uh/preview-magiclink-prefix [] (:preview-magiclink handlers))
+           (GET "/meta/" [] (:meta handlers))
            (GET "/meta/:component" [] (:meta handlers))
            (GET "/" [] process-root-get)
            (not-found "<p>Resource not found</p>"))

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -1057,7 +1057,7 @@
            (POST uh/register-magiclink-prefix [] (:register-magiclink handlers))
            (GET uh/get-magiclink-prefix [] (:get-magiclink handlers))
            (POST uh/preview-magiclink-prefix [] (:preview-magiclink handlers))
-           (GET "/meta/" [] (:meta handlers))
+           (GET "/meta" [] (:meta handlers))
            (GET "/meta/:component" [] (:meta handlers))
            (GET "/" [] process-root-get)
            (not-found "<p>Resource not found</p>"))

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -252,7 +252,9 @@
         (if-not (seq params)
           (ok {:components (cn/component-names)})
           (let [c (keyword (:component params))]
-            (ok {:paths (paths-info c) :schema (schema-info c) :component-edn (str (lr/as-edn c))}))))))
+            (ok {:paths (paths-info c)
+                 :schema (schema-info c)
+                 :component-edn (str (vec (rest (lr/as-edn c))))}))))))
 
 (defn- process-gpt-chat [[_ maybe-unauth] request]
   (or (maybe-unauth request)


### PR DESCRIPTION
fixes #1236 

1. `GET /meta/<component-name>` will return user-defined spec for entities, records and relationships.
2. `GET /meta` will return a list of all component namers.