### PR TITLE
Dataflow debugger with HTTP API support

### DIFF
--- a/src/fractl/compiler.cljc
+++ b/src/fractl/compiler.cljc
@@ -442,10 +442,10 @@
               #(compile-pattern ctx np))))
         opcode inst-alias]))))
 
-(defn- package-opcode [code]
+(defn- package-opcode [code pat]
   (if (and (map? code) (:opcode code))
     code
-    {:opcode code}))
+    {:opcode code :pattern pat}))
 
 (defn- some-query-attrs? [attrs]
   (when (some li/query-pattern? (keys attrs))
@@ -962,7 +962,7 @@
                (i/const-value? pat) compile-literal
                (seqable? pat) compile-fncall-expression)]
     (let [code (c ctx pat)]
-      (package-opcode code))
+      (package-opcode code pat))
     (u/throw-ex (str "cannot compile invalid pattern - " pat))))
 
 (defn- maybe-mark-conditional-df [ctx evt-pattern]

--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -785,6 +785,12 @@
 
     :else x))
 
+(defn unmake-instance [inst]
+  (if (an-instance? inst)
+    (let [n (instance-type-kw inst)]
+      {n (instance-attributes inst)})
+    inst))
+
 (defn- maps-to-insts
   "If any of the values in the attributes map itself is the
    map-encoded representation of a record or entity, convert

--- a/src/fractl/env.cljc
+++ b/src/fractl/env.cljc
@@ -1,7 +1,8 @@
 (ns fractl.env
   "The environment of instance and variable bindings,
   used for pattern resolution."
-  (:require [fractl.util :as u]
+  (:require [clojure.string :as s]
+            [fractl.util :as u]
             [fractl.util.seq :as su]
             [fractl.lang.internal :as li]
             [fractl.component :as cn]))
@@ -20,13 +21,8 @@
   (and (map? x)
        (env-tag x)))
 
-(defn get-store
-  [self]
-  (:store self))
-
-(defn get-resolver
-  [self]
-  (:resolver self))
+(def get-store :store)
+(def get-resolver :resolver)
 
 ;; !!NOTE!! This assertion may be removed once the
 ;; pattern-match algorithm is fully implemented.
@@ -304,7 +300,7 @@
 (defn disable-post-event-triggers [env]
   (dissoc env post-event-trigger-sources))
 
-(def pattern-evaluator :*-*-pattern-evaluator-*-)
+(def pattern-evaluator :-*-pattern-evaluator-*-)
 
 (defn assoc-pattern-evaluator [env f]
   (assoc env pattern-evaluator f))
@@ -314,3 +310,22 @@
 (defn assoc-rule-futures [env fs]
   (let [rfs (rule-futures env)]
     (assoc env rule-futures (concat rfs fs))))
+
+(defn cleanup [env]
+  (let [env (dissoc env :dirty :store :resolver :objstack)
+        df-vals (filter (fn [[k _]]
+                          (if (keyword? k)
+                            (not (s/starts-with? (name k) "-*-"))
+                            true))
+                        env)
+        norm-vals (mapv (fn [[k v]]
+                          [(if (vector? k)
+                             (li/make-path k)
+                             k)
+                           (cond
+                             (map? v) (cn/unmake-instance v)
+                             (string? v) v
+                             (seqable? v) (mapv cn/unmake-instance v)
+                             :else v)])
+                        df-vals)]
+    (into {} norm-vals)))

--- a/src/fractl/evaluator.cljc
+++ b/src/fractl/evaluator.cljc
@@ -306,6 +306,9 @@
   ([env pattern] (evaluate-pattern env nil nil pattern))
   ([pattern] (evaluate-pattern nil nil pattern)))
 
+(defn debug-dataflow [event-instance]
+  (first (cn/dataflows-for-event (cn/instance-type (cn/make-instance event-instance)))))
+
 (defn eval-all-dataflows
   ([event-obj store-or-store-config resolver-or-resolver-config]
    (let [ef (evaluator store-or-store-config resolver-or-resolver-config)]

--- a/src/fractl/evaluator/root.cljc
+++ b/src/fractl/evaluator/root.cljc
@@ -1062,7 +1062,7 @@
             env (env/assoc-active-event env inst)
             df (first
                 (cl/compile-dataflows-for-event
-                 (partial store/compile-query (:store env))
+                 (partial store/compile-query (env/get-store env))
                  (if with-types
                    (assoc inst li/with-types-tag with-types)
                    inst)))

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -581,6 +581,11 @@
       (let [id (get-in request [:params :id])]
         (ok (ev/debug-step id)))))
 
+(defn- process-debug-continue [evaluator [auth-config maybe-unauth] request]
+  (or (maybe-unauth request)
+      (let [id (get-in request [:params :id])]
+        (ok (ev/debug-continue id)))))
+
 (defn- process-delete-debug-session [evaluator [auth-config maybe-unauth] request]
   (or (maybe-unauth request)
       (let [id (get-in request [:params :id])]
@@ -1115,7 +1120,8 @@
            (GET (str uh/entity-event-prefix "*") [] (:get-request handlers))
            (DELETE (str uh/entity-event-prefix "*") [] (:delete-request handlers))
            (POST uh/debug-prefix [] (:start-debug-session handlers))
-           (GET (str uh/debug-prefix "/:id") [] (:debug-step handlers))
+           (PUT (str uh/debug-prefix "/step/:id") [] (:debug-step handlers))
+           (PUT (str uh/debug-prefix "/continue/:id") [] (:debug-continue handlers))
            (DELETE (str uh/debug-prefix "/:id") [] (:delete-debug-session handlers))
            (POST uh/query-prefix [] (:query handlers))
            (POST uh/dynamic-eval-prefix [] (:eval handlers))
@@ -1197,6 +1203,7 @@
             :delete-request (partial process-delete-request evaluator auth-info)
             :start-debug-session (partial process-start-debug-session evaluator auth-info)
             :debug-step (partial process-debug-step evaluator auth-info)
+            :debug-continue (partial process-debug-continue evaluator auth-info)
             :delete-debug-session (partial process-delete-debug-session evaluator auth-info)
             :query (partial process-query evaluator auth-info)
             :eval (partial process-dynamic-eval evaluator auth-info nil)

--- a/src/fractl/util/http.cljc
+++ b/src/fractl/util/http.cljc
@@ -54,6 +54,7 @@
 (def auth-prefix "/auth")
 (def auth-callback-prefix "/auth/callback")
 (def ai-prefix "/ai")
+(def debug-prefix "/debug")
 (def register-magiclink-prefix "/register-magiclink")
 (def get-magiclink-prefix "/get-magiclink")
 (def preview-magiclink-prefix "/preview-magiclink")

--- a/test/fractl/test/features04.cljc
+++ b/test/fractl/test/features04.cljc
@@ -2,6 +2,7 @@
   (:require #?(:clj [clojure.test :refer [deftest is]]
                :cljs [cljs.test :refer-macros [deftest is]])
             [fractl.component :as cn]
+            [fractl.evaluator :as ev]
             [fractl.lang.internal :as li]
             [fractl.lang
              :refer [component attribute event
@@ -540,3 +541,14 @@
       (chk b2 a1)
       (chk b3 a2)
       (lkp b1) (lkp b2) (lkp b3))))
+
+(deftest debugger-01
+  (defcomponent :Dbg01
+    (entity :Dbg01/A {:Id :Identity :X :Int})
+    (entity :Dbg01/B {:Id :Identity :Y :Int})
+    (event :Dbg01/E {:X :Int})
+    (dataflow
+     :Dbg01/E
+     {:Dbg01/A {:X :Dbg01/E.X} :as :A}
+     {:Dbg01/B {:Y '(+ 100 :A.X)}}))
+  (is (ev/debug-dataflow {:Dbg01/E {:X 20}})))

--- a/test/sample/simple.fractl
+++ b/test/sample/simple.fractl
@@ -22,6 +22,14 @@
  :Q
  {:E1? {}})
 
+(entity :T {:X :Int})
+(entity :U {:Y :Int})
+
+(dataflow
+ :TU
+ {:T {:X :TU.X} :as :T1}
+ {:U {:Y '(* :T1.X 100)}})
+
 (record
  {:Result
   {:Data :Any}})


### PR DESCRIPTION
Note: This initial version of the debugger maintains sessions in memory - objective of the PR is to get the public interface reviewed.

Start a debugging session:

```
POST /debug
{"EventName": {"Attribute": "Value"}}
```

This will return a debug-session-id. To step:

```
PUT /debug/step/<id>
```

The response will be in the format `[session-id result-map]`, where `result-map` will contain the keys - 
    `:status` - the status of evaluating the next pattern - `:ok` or `:error`.
    `:result` - the value of the pattern 
    `:env` - the local value bindings of the evaluator
    `:pattern` - the original pattern that was evaluated

To continue from the current to the last step:

```
PUT /debug/continue/id
```

The `continue` API will return the value of the last pattern that was evaluated.

To cancel a debug-session:

```
DELETE /debug/<id>
```

Note that when the last pattern in the debugged-dataflow is evaluated, the session is automatically cancelled and cannot be reused. 