### PR TITLE
fix escape quoted strings in clickhouse

### DIFF
--- a/src/fractl/resolver/click_house.clj
+++ b/src/fractl/resolver/click_house.clj
@@ -52,10 +52,12 @@
         table-name (as-table-name n)
         attrs (cn/instance-attributes instance)
         anames (keys attrs)
+        values (str-csv #(as-quoted-sql-val (% attrs)) anames)
+        values (s/replace values #"\\\"" "\\\\\\\\\"")
         sql (str "INSERT INTO " table-name " ("
                  (str-csv name anames)
                  ") VALUES ("
-                 (str-csv #(as-quoted-sql-val (% attrs)) anames)
+                 values
                  ")")]
     (execute-sql ds sql)
     instance))


### PR DESCRIPTION
Escaped string values like `"[\"abc\": 123]"` turn into `"["abc": 123]"` when inserting them into Clickhouse. It causes parsing errors when retrieving it.

The solution is to turn it into `"[\\\"abc\\\": 123]"` before inserting.