### PR TITLE
Handle inference in the script loader.

### DIFF
--- a/src/fractl/compiler/validation.cljc
+++ b/src/fractl/compiler/validation.cljc
@@ -17,9 +17,10 @@
   "Return the set of attributes in the pattern, that is not in the
   original schema. Return nil if there is no difference."
   [pattern-attrs schema]
-  (let [orig-attrs (cn/attribute-names schema)
-        pattrs (set (map li/normalize-name (keys pattern-attrs)))]
-    (seq (set/difference pattrs orig-attrs))))
+  (when-not (cn/inferred-event-schema? schema)
+    (let [orig-attrs (cn/attribute-names schema)
+          pattrs (set (map li/normalize-name (keys pattern-attrs)))]
+      (seq (set/difference pattrs orig-attrs)))))
 
 (def validate-attribute-value cn/validate-attribute-value)
 

--- a/src/fractl/lang/name_util.cljc
+++ b/src/fractl/lang/name_util.cljc
@@ -176,6 +176,7 @@
    'view fq-preproc-record-def
    'event fq-preproc-record-def
    'relationship fq-preproc-record-def
+   'inference fq-preproc-record-def
    'rule fq-preproc-rule-def
    'dataflow fq-preproc-dataflow-def})
 


### PR DESCRIPTION
Do not enforce schema check on inferred-event pattern.