### PR TITLE
Support for model-specific config entities

### DIFF
--- a/fractl/fractl/kernel/lang.fractl
+++ b/fractl/fractl/kernel/lang.fractl
@@ -99,6 +99,9 @@
   :DestinationUri {:type :String
                    :optional true}})
 
+;; Base-type of model-configuration entities.
+(record :Config {:Id {:type :Int :guid true :default 1 :read-only true}})
+
 (r/register-resolvers
  [{:name :meta
    :type :meta

--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -27,9 +27,11 @@
   (u/safe-set models (assoc @models model-name spec))
   model-name)
 
+(defn model-names [] (keys @models))
 (defn fetch-model [name] (get @models name))
-
-(defn model-version [name] (:version (fetch-model name)))
+(defn model-property [prop name] (prop (fetch-model name)))
+(def model-version (partial model-property :version))
+(def model-config-entity (partial model-property :config-entity))
 
 (defn model-for-component [component-name]
   (ffirst (filter (fn [[_ spec]]

--- a/src/fractl/evaluator.cljc
+++ b/src/fractl/evaluator.cljc
@@ -518,9 +518,9 @@
     (mapv (partial save-model-config-instance app-config) (cn/model-names))))
 
 (defn fetch-model-config-instance [model-name]
-  (let [model-name (if (keyword? model-name)
-                     model-name
-                     (keyword model-name))]
+  (let [model-name (if (li/quoted? model-name)
+                     (second model-name)
+                     model-name)]
     (when-let [ent (cn/model-config-entity model-name)]
       (let [evt-name (cn/crud-event-name ent :LookupAll)]
         (first (safe-eval-internal {evt-name {}}))))))

--- a/src/fractl/model/fractl/kernel/identity.cljc
+++ b/src/fractl/model/fractl/kernel/identity.cljc
@@ -14,6 +14,7 @@
     rule
     relationship
     component
+    resolver
     event
     inference
     record]]))
@@ -92,4 +93,4 @@
  [:delete :Fractl.Kernel.Rbac/RoleAssignment :purge])
 (def
  Fractl_Kernel_Identity___COMPONENT_ID__
- "4d3d1d49-766b-45b9-9401-61e6e6165ee2")
+ "1e60ab15-6b3c-41a8-bacf-b8a09570a8d1")

--- a/src/fractl/model/fractl/kernel/lang.cljc
+++ b/src/fractl/model/fractl/kernel/lang.cljc
@@ -17,6 +17,7 @@
     rule
     relationship
     component
+    resolver
     event
     inference
     record]]))
@@ -33,7 +34,7 @@
 (attribute :Fractl.Kernel.Lang/String {:check k/kernel-string?})
 (attribute
  :Fractl.Kernel.Lang/Keyword
- {:check (fn* [p1__292#] (or (keyword? p1__292#) (string? p1__292#)))})
+ {:check (fn* [p1__284#] (or (keyword? p1__284#) (string? p1__284#)))})
 (attribute :Fractl.Kernel.Lang/Path {:check k/path?})
 (attribute :Fractl.Kernel.Lang/DateTime {:check k/date-time?})
 (attribute :Fractl.Kernel.Lang/Date {:check k/date?})
@@ -104,6 +105,13 @@
  :Fractl.Kernel.Lang/DataSync
  {:Source :Fractl.Kernel.Lang/DataSource,
   :DestinationUri {:type :Fractl.Kernel.Lang/String, :optional true}})
+(record
+ :Fractl.Kernel.Lang/Config
+ {:Id
+  {:type :Fractl.Kernel.Lang/Int,
+   :guid true,
+   :default 1,
+   :read-only true}})
 (r/register-resolvers
  [{:name :meta,
    :type :meta,
@@ -128,4 +136,4 @@
     :paths [:Fractl.Kernel.Lang/DataSync]})])
 (def
  Fractl_Kernel_Lang___COMPONENT_ID__
- "6de04925-7087-483e-8f53-7ac37e122207")
+ "f80edde8-df4d-429f-9429-004c4e21b750")

--- a/src/fractl/model/fractl/kernel/rbac.cljc
+++ b/src/fractl/model/fractl/kernel/rbac.cljc
@@ -18,6 +18,7 @@
     rule
     relationship
     component
+    resolver
     event
     inference
     record]]))
@@ -35,7 +36,7 @@
 (defn-
  crud-list?
  [xs]
- (every? (fn* [p1__296#] (some #{p1__296#} oprs)) (set xs)))
+ (every? (fn* [p1__288#] (some #{p1__288#} oprs)) (set xs)))
 (entity
  :Fractl.Kernel.Rbac/Privilege
  {:Name {:type :String, :default u/uuid-string, li/guid true},
@@ -78,7 +79,7 @@
    " in ("
    (s/join
     ","
-    (map (fn* [p1__297#] (str "'" (str p1__297#) "'")) role-names))
+    (map (fn* [p1__289#] (str "'" (str p1__289#) "'")) role-names))
    "))")))
 (dataflow
  :Fractl.Kernel.Rbac/FindPrivilegeAssignments
@@ -98,7 +99,7 @@
    " in ("
    (s/join
     ","
-    (map (fn* [p1__298#] (str "'" (str p1__298#) "'")) names))
+    (map (fn* [p1__290#] (str "'" (str p1__290#) "'")) names))
    "))")))
 (dataflow
  :Fractl.Kernel.Rbac/FindPrivileges
@@ -129,4 +130,4 @@
                        :Assignee {:type :String, :indexed true}}})
 (def
  Fractl_Kernel_Rbac___COMPONENT_ID__
- "c0888378-fa1b-4f2f-a974-b92e83b1651f")
+ "62efa96d-e60e-48b4-98aa-e4d0560fade9")

--- a/src/fractl/util/core.clj
+++ b/src/fractl/util/core.clj
@@ -114,7 +114,8 @@
     (log-app-init-result! result)))
 
 (defn run-appinit-tasks! [evaluator init-data]
-    (trigger-appinit-event! evaluator init-data))
+  (e/save-model-config-instances)
+  (trigger-appinit-event! evaluator init-data))
 
 (defn merge-resolver-configs [app-config resolver-configs]
   (let [app-resolvers (:resolvers app-config)]


### PR DESCRIPTION
Example:

```clojure
; model.fractl
{:name "blog"
 :fractl-version "0.5.1"
 :components [:Blog.Core]
 :config-entity :Blog.Core/Config}
```

```clojure
; config.edn
{:service {:port 8000}
 :store {:type :h2
         :dbname "./data/blog"}
 :Blog.Core/Config {:RemoteHost "https://remote.blog.com"}}
```

Config entity definition:

```clojure
(entity
 :Blog.Core/Config
 {:meta {:inherits :Fractl.Kernel.Lang/Config}
  :RemoteHost :String})
```

Accessing the config instance from a dataflow pattern:

```clojure
{:Blog.Core/Config? {} :as [:config]}
{:Remote/Blog {:Id? "123" :Host :config.RemoteHost}}
```

Accessing config instance from clojure:

```
(fractl.evaluator/fetch-model-config-instance "blog") 
```
