### PR TITLE
Run the require namespaces before init,

### DIFF
--- a/src/fractl/lang.cljc
+++ b/src/fractl/lang.cljc
@@ -1249,11 +1249,11 @@
 ;;
 (defn resolver [n spec]
   #?(:clj
-     (u/set-on-init!
-      (fn []
-        (let [req (:require spec)]
-          (when-let [nss (:namespaces req)]
-            (apply require nss))
+     (let [req (:require spec)]
+       (when-let [nss (:namespaces req)]
+         (apply require nss))
+       (u/set-on-init!
+        (fn []
           (let [s0 (dissoc spec :require :with-methods :with-subscription)
                 res-spec (assoc s0 :name n)
                 maybe-subs #(when-let [subs (:with-subscription spec)]

--- a/src/fractl/util/http.cljc
+++ b/src/fractl/util/http.cljc
@@ -62,7 +62,7 @@
 (def post-copilot-question "/post-copilot-question")
 
 (defn- remote-resolver-error [response]
-  (u/throw-ex (str "remote resolver error - " (or (:error response) response))))
+  (u/throw-ex (str "remote service error - " (or (:error response) response))))
 
 (defn- response-handler [format callback response]
   ((or callback identity)


### PR DESCRIPTION
 so any pending resolver-type registration can happen.