### PR TITLE
nREPL fix and config options

### DIFF
--- a/src/fractl/core.clj
+++ b/src/fractl/core.clj
@@ -281,17 +281,17 @@
                                                          (let [model-info (ur/read-model-and-config opts)
                                                                [[ev store] _] (ur/prepare-repl-runtime model-info)]
                                                            (repl/run model-name store ev)))))))
-:nrepl (ur/run-repl-func options
-                         (fn [model-name opts]
-                           (let [nrepl-config (get-in opts [:-*-config-data-*- :nrepl] {})
-                                 bind (:bind nrepl-config)
-                                 port (or (:port nrepl-config) 7888)
-                                 server-opts (cond-> {:port port
-                                                      :handler (fractl-nrepl-handler model-name opts)}
-                                               bind (assoc :bind bind))]
-                             (apply nrepl.server/start-server (mapcat identity server-opts))
-                             (println (str "nREPL server running on port " port
-                                           (when bind (str " and bound to " bind)))))))
+                 :nrepl (ur/run-repl-func options
+                                          (fn [model-name opts]
+                                            (let [nrepl-config (get-in opts [:-*-config-data-*- :nrepl] {})
+                                                  bind (:bind nrepl-config)
+                                                  port (or (:port nrepl-config) 7888)
+                                                  server-opts (cond-> {:port    port
+                                                                       :handler (fractl-nrepl-handler model-name opts)}
+                                                                      bind (assoc :bind bind))]
+                                              (apply nrepl.server/start-server (mapcat identity server-opts))
+                                              (println (str "nREPL server running on port " port
+                                                            (when bind (str " and bound to " bind)))))))
                  :publish #(println (publish-library %))
                  :deploy #(println (d/deploy (:deploy basic-config) (first %)))
                  :db:migrate #(ur/call-after-load-model


### PR DESCRIPTION
nREPL uses a default port of 7888. So, reverting to it. To allow flexibility for change, the config specification could be used:
```
 :nrepl {:port 7000
          :bind "127.0.0.1"}
```