### PR TITLE
GraphQL resolver and schema generation to support filters, offset, limit

### DIFF
--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -31,6 +31,7 @@
     :-*-containers-*-
     :Fractl.Kernel.UserApp
     :Fractl.Kernel.Repl
+    :Fractl.Inference.Service
     })
 
 (def non-instance-user-attr-keys


### PR DESCRIPTION
Improved automatic GraphQL resolver and schema code generation to support complex filters with arbitrary depth.

Supported comparison operators:
- eq (equal)
- ne (not equal)
- gt (greater than)
- gte (greater than or equal)
- lt (less than)
- lte (less than or equal)
- in (value in list)
- contains (string contains)
- startsWith (string starts with)
- endsWith (string ends with)
- between (value between two numbers)

Logical operators:
- AND
- OR
- NOT

Example Query:

```graphql
query getMultiConditionFilteredHeros($filter: HeroFilter) {
  Hero (filter: $filter) {
    Id
    Name
    HomePlanet
    Age
    ForceSensitive
  }
}

Variables:
{
  "filter": {
    "and": [
      {
        "or": [
          { "Age": { "gte": 30, "lt": 100 } },
          {
            "and": [
              { "Age": { "gte": 20, "lt": 30 } },
              { "ForceSensitive": true }
            ]
          }
        ]
      },
      { "not": { "HomePlanet": { "eq": "Kashyyyk" } } },
      {
        "or": [
          { "Name": { "contains": "a" } },
          { "HomePlanet": { "in": ["Tatooine", "Alderaan"] } }
        ]
      }
    ]
  }
}
```

![image](https://github.com/fractl-io/fractl/assets/30462034/00e55b08-cfe3-4d16-8248-ec2283be920b)
