### PR TITLE
Support arbitrary depth of records in graphql queries and mutations, Filter Generation Fix

### DIFF
--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -32,6 +32,7 @@
     :Fractl.Kernel.UserApp
     :Fractl.Kernel.Repl
     :Fractl.Inference.Service
+    :Fractl.Inference.Provider
     })
 
 (def non-instance-user-attr-keys

--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -31,6 +31,7 @@
     :-*-containers-*-
     :Fractl.Kernel.UserApp
     :Fractl.Kernel.Repl
+    :Fractl.Inference.Service
     })
 
 (def non-instance-user-attr-keys

--- a/src/fractl/graphql/resolvers.clj
+++ b/src/fractl/graphql/resolvers.clj
@@ -242,12 +242,43 @@
                true (drop offset)
                limit (take limit)))))
 
+(defn transform-pattern
+  "Transforms a pattern by wrapping maps with their corresponding record types."
+  [records pattern]
+  (letfn [(find-record-type [value]
+            (some (fn [record]
+                    (when (= (set (keys (val (first record)))) (set (keys value)))
+                      (key (first record))))
+                  records))
+          (wrap-record [record-type data]
+            (if (map? data)
+              {record-type data}
+              data))
+          (process-value [value]
+            (cond
+              (vector? value)
+              (mapv process-value value)
+
+              (map? value)
+              (if-let [record-type (find-record-type value)]
+                (wrap-record record-type (into {} (map (fn [[k v]] [k (process-value v)]) value)))
+                (into {} (map (fn [[k v]] [k (process-value v)]) value)))
+              :else
+              value))]
+    (process-value pattern)))
+
 (defn create-entity-resolver
   [entity-name]
   (fn [context args value]
     (let [args (:input args)
           core-component (:core-component context)
-          create-pattern {entity-name args}]
+          schema-info (schema-info core-component)
+          records (:records schema-info)
+          create-pattern {entity-name args}
+          attr-map-key (first (keys create-pattern))
+          attr-map-value (get create-pattern attr-map-key)
+          transformed-attr-map (transform-pattern records attr-map-value)
+          create-pattern {attr-map-key transformed-attr-map}]
       (first (eval-patterns core-component create-pattern context)))))
 
 (defn create-contained-entity-resolver
@@ -274,17 +305,29 @@
           create-pattern {relationship-name args}]
       (first (eval-patterns core-component create-pattern context)))))
 
+(defn transform-update-pattern
+  [records pattern]
+  (let [update-key (first (keys pattern))
+        update-value (get pattern update-key)
+        id (:Id update-value)
+        data (:Data update-value)
+        transformed-data (transform-pattern records data)
+        result {update-key {:Id id :Data transformed-data}}]
+    result))
+
 (defn update-entity-resolver
   [entity-name]
   (fn [context args value]
     (let [args (:input args)
           core-component (:core-component context)
-          schema (schema-info core-component)
-          entity-guid-attr (find-guid-or-id-attribute schema entity-name)
+          schema-info (schema-info core-component)
+          entity-guid-attr (find-guid-or-id-attribute schema-info entity-name)
           entity-guid-val (entity-guid-attr args)
           update-pattern {(form-pattern-name core-component "Update" (extract-entity-name entity-name))
                           {entity-guid-attr entity-guid-val
-                           :Data            (dissoc args entity-guid-attr)}}]
+                           :Data            (dissoc args entity-guid-attr)}}
+          records (:records schema-info)
+          update-pattern (transform-update-pattern records update-pattern)]
       (first (eval-patterns core-component update-pattern context)))))
 
 (defn update-contained-entity-resolver

--- a/src/fractl/http.clj
+++ b/src/fractl/http.clj
@@ -5,6 +5,7 @@
             [buddy.auth.middleware :refer [wrap-authentication]]
             [buddy.sign.jwt :as buddyjwt]
             [clj-time.core :as time]
+            [clojure.string :as str]
             [clojure.string :as s]
             [clojure.walk :as w]
             [fractl.auth.core :as auth]
@@ -1168,9 +1169,9 @@
          schema (cn/schema-info core-component-name)
          contains-graph-map (gg/generate-contains-graph schema)
          [auth _ :as auth-info] (make-auth-handler config)]
-      (try
-       ; attempt to compile the GraphQL schema
-       (let [[uninjected-graphql-schema injected-graphql-schema entity-metadatas] (graphql/compile-graphql-schema schema contains-graph-map)]
+       (try
+         ; attempt to compile the GraphQL schema
+         (let [[uninjected-graphql-schema injected-graphql-schema entity-metadatas] (graphql/compile-graphql-schema schema contains-graph-map)]
          ; save schema to global variable and file
          (graphql/save-schema uninjected-graphql-schema)
          (reset! core-component core-component-name)
@@ -1178,8 +1179,9 @@
          (reset! graphql-entity-metas entity-metadatas)
          (reset! contains-graph contains-graph-map)
          (log/info (str "GraphQL schema generation and resolver injection succeeded.")))
-       (catch Exception e
-         (log/error (str "Failed to compile GraphQL schema:" e))))
+         (catch Exception e
+           (log/error (str "Failed to compile GraphQL schema:"
+                           (str/join "\n" (.getStackTrace e))))))
 
      (if (or (not auth) (auth-service-supported? auth))
        (let [config (merge {:port 8080 :thread (+ 1 (u/n-cpu))} config)]


### PR DESCRIPTION
Please see unit tests for examples of deeply nested queries and mutations. 

PR also fixes the bug affecting the absence of between relationship filter objects. 