### PR TITLE
Parse record-name to parts in a direct call to make-instance

### DIFF
--- a/src/fractl/component.cljc
+++ b/src/fractl/component.cljc
@@ -903,7 +903,8 @@
    full-record-name must be in the form - :ComponentName/RecordName.
    Return the new record on success, return an :error record on failure."
   ([record-name attributes validate?]
-   (let [schema (ensure-schema record-name)
+   (let [record-name (li/split-path record-name)
+         schema (ensure-schema record-name)
          attrs-with-insts (maps-to-insts attributes validate?)
          attrs (if validate?
                  (validate-record-attributes record-name attrs-with-insts schema)

--- a/test/fractl/test/errors.cljc
+++ b/test/fractl/test/errors.cljc
@@ -120,7 +120,7 @@
     (evaluate-request-and-verify-client-error-response {:Api.Test/MakeF {:Name "Nice Name"
                                                                          :Y 100
                                                                          :ExtraUndefinedAttribute "Some value"}}
-                                                       ":Api.Test/MakeF - invalid attribute(s) found - (:ExtraUndefinedAttribute)")))
+                                                       "[:Api.Test :MakeF] - invalid attribute(s) found - (:ExtraUndefinedAttribute)")))
 
 (deftest verify-various-client-msg-configuration-scenarios-for-raised-errors
   (testing "With client message same as internal error message"


### PR DESCRIPTION
This is required to maintain compatibility with the dataflow compilation process and runtime internals, where all names as treated as a vector of keywords, as in `[:ComponentName :EntityName]`.